### PR TITLE
Increase Persephone diff threshold to reduce false positives

### DIFF
--- a/persephone/builds/models.py
+++ b/persephone/builds/models.py
@@ -254,7 +254,7 @@ class Build(models.Model):
 
 
 class Screenshot(models.Model):
-    DIFF_EPSILON = 1e-4
+    DIFF_EPSILON = 2e-4
 
     STATE_PENDING = 0
     STATE_MATCHING = 1


### PR DESCRIPTION
## **Why**
We’re seeing consistent visual “diffs” caused by sub‑pixel anti‑aliasing noise (rounded corners, SVGs, borders) rather than real UI changes.

## **What changed**
Bumped `DIFF_EPSILON` in `models.py` from `1e-4` to `2e-4` so tiny RMS noise doesn’t trigger diffs.